### PR TITLE
Load required buildpacks and force static rendering

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/boot

--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-static"
+    },
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}

--- a/static.json
+++ b/static.json
@@ -1,5 +1,5 @@
 {
-  "root": "dist",
+  "root": "dist/",
   "clean_urls": true,
   "routes": {
     "/**": "index.html"


### PR DESCRIPTION
This adds the `app.json` manifest with instructions to load the static and nodejs buildpacks. It also adds a Procfile to ensure static rendering (see https://github.com/heroku/heroku-buildpack-static#procfile--multiple-buildpacks). 

#### How can a reviewer manually see the effects of these changes?
The [review app](https://disco-pipeli-add-app-js-upgfvu.herokuapp.com/) should load the nodejs and static buildpacks and run without errors.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-22
- https://mitlibraries.atlassian.net/browse/DISCO-14

#### Includes new or updated dependencies?
NO
