### PR TITLE
DISCO-69 Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This adds the config file required for GitHub-native dependabot. More info here: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates

#### How can a reviewer manually see the effects of these changes?
I'm not sure. You can check if dependabot is configured by going to Insights > Dependency graph > Dependabot tab, but it seems to monitor the main branch only. We could temporarily designate this branch as main to see if dependency PRs pop up, but I'll leave it to the team as to whether that's necessary.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-69

#### Includes new or updated dependencies?
NO
