### PR TITLE
Adds yarn lint step to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install packages
-      run: npm install
+      run: yarn install
     - name: Run tests
-      run: npm run test:unit
+      run: yarn test:unit
+    - name: build
+      run: yarn build
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install packages
+      run: yarn install
+    - name: Run linter
+      run: yarn lint --no-fix --max-warnings 0


### PR DESCRIPTION
This reconfigures the steps that GitHub Actions takes on Pull Requests:

The "build" workflow which we've had in the past is now using Yarn, and includes running `yarn build` should the tests pass. This seems like it should be useful in determining if something has slipped into the code that could cause Heroku to fail - but I'm happy to take this out if desired.

There is also a new "lint" workflow, which runs the command `yarn lint --no-fix --max-warnings 0` . This forces the linter into a strict checking tool, rather than its default of operating in a "fix the problems" mode. This command is applied to the entire codebase, so if we ever run across a problem that we decide to overlook we'll need to look into whitelisting or further steps at that point.

#### How can a reviewer manually see the effects of these changes?

Inspect the GitHub Actions reports on the bottom of this PR.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-88

#### Todo:
- [ ] Documentation

What documentation needs to change as a result of this? I'm honestly not sure, but it feels like something should.

#### Includes new or updated dependencies?
NO
