### PR TITLE
Hidey-Showey: Hides empty components, allows them to show when relevant

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,15 +6,22 @@
       <div class="wrap-content">
         <div class="layout-band">
           <SearchForm @searched="doSearch" />
+          <SearchMetadata
+            v-if="showSearchMetadata"
+            v-model:query.lazy="query"
+            v-model:status="status"
+            v-model:hits="hits"
+          />
         </div>
-        <div class="layout-1q2q1q layout-band">
-          <div class="col1q">
-            <Facet msg="Subject facet" />
-            <Facet msg="Author facet" />
-            <Facet msg="Publisher facet" />
-            <Facet msg="Title facet" />
+        <div v-bind:class="layoutBand">
+          <div v-if="sidebarLeft" class="col1q">
+            <Facet
+              v-for="facet in facets"
+              v-bind:facet="facet"
+              v-bind:key="facet"
+            />
           </div>
-          <div class="content-main">
+          <div v-bind:class="layoutContent">
             <div v-if="status.loading" class="panel panel-info">
               <div class="panel-heading">Loading...</div>
             </div>
@@ -32,18 +39,19 @@
               v-bind:index="index"
               v-bind:key="result.id"
             />
-            <Pagination msg="Pagination bar" />
-            <Record msg="Full record for display" />
+            <Pagination v-if="showPagination" msg="Pagination bar" />
+            <Record v-if="record" v-model="record" />
           </div>
-          <div class="col1q-r">
-            <Related msg="Related libraries" />
-            <Related msg="Related items" />
-            <Related msg="Related librarians" />
-            <Related msg="Related links" />
+          <div v-if="sidebarRight" class="col1q-r">
+            <Related
+              v-for="related in relateds"
+              v-bind:related="related"
+              v-bind:key="related"
+            />
           </div>
         </div>
-        <Help msg="This is the help area." />
-        <About msg="This is the about panel." />
+        <Help v-if="help" v-model="help" />
+        <About v-if="about" v-model="about" />
       </div>
     </div>
     <Footer />
@@ -62,6 +70,7 @@ import Pagination from "./components/Pagination.vue";
 import Record from "./components/Record.vue";
 import Related from "./components/Related.vue";
 import SearchForm from "./components/SearchForm.vue";
+import SearchMetadata from "./components/SearchMetadata.vue";
 
 export default {
   name: "App",
@@ -76,23 +85,31 @@ export default {
     Pagination,
     Record,
     Related,
-    SearchForm
+    SearchForm,
+    SearchMetadata
   },
   data() {
     return {
+      about: undefined,
+      facets: [],
+      help: undefined,
+      hits: 0,
       query: "",
+      record: undefined,
+      results_per_page: process.env.VUE_APP_RESULTS_PER_PAGE || 5,
+      relateds: [],
       results: [],
       status: {
         error_message: "",
         errored: false,
-        loading: false
+        loading: false,
+        ready: false
       }
     };
   },
   methods: {
     doSearch: function(query) {
       if (query) {
-        console.log("App has been instructed to search for _" + query + "_");
         this.query = query;
         this.results = [{ id: 1, title: "Retrieving results..." }];
         this.searchTimdex(query);
@@ -101,9 +118,16 @@ export default {
     searchTimdex: function(query) {
       const axios = require("axios").default;
       this.status.loading = true;
+      this.status.ready = false;
       axios
-        .get("https://timdex.mit.edu/api/v1/search?q=" + query)
-        .then(response => (this.results = response.data.results))
+        .get(String(process.env.VUE_APP_TIMDEX_API) + query)
+        .then(
+          response => (
+            (this.results = response.data.results),
+            (this.hits = response.data.hits),
+            (this.status.ready = true)
+          )
+        )
         .catch(
           error => (
             (this.status.errored = true),
@@ -112,6 +136,46 @@ export default {
           )
         )
         .finally(() => (this.status.loading = false));
+    }
+  },
+  computed: {
+    layoutBand: function() {
+      if (this.sidebarLeft && this.sidebarRight) {
+        return "layout-1q2q1q";
+      } else if (this.sidebarLeft) {
+        return "layout-1q3q";
+      } else if (this.sidebarRight) {
+        return "layout-3q1q";
+      }
+      return "";
+    },
+    layoutContent: function() {
+      if (this.sidebarLeft && this.sidebarRight) {
+        return "content-main";
+      } else if (this.sidebarLeft) {
+        return "col3q";
+      } else if (this.sidebarRight) {
+        return "col3q";
+      }
+      return "";
+    },
+    showPagination: function() {
+      return this.hits > this.results_per_page ? true : false;
+    },
+    showSearchMetadata: function() {
+      if (this.query === "") {
+        return false;
+      }
+      if (this.status.errored === true) {
+        return false;
+      }
+      return true;
+    },
+    sidebarLeft: function() {
+      return this.facets.length ? true : false;
+    },
+    sidebarRight: function() {
+      return this.relateds.length ? true : false;
     }
   }
 };

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="about component bit">
     <h3 class="title">About</h3>
-    <p>{{ msg }}</p>
+    <p>{{ modelValue }}</p>
   </div>
 </template>
 
@@ -9,7 +9,7 @@
 export default {
   name: "About",
   props: {
-    msg: String
+    modelValue: String
   }
 };
 </script>

--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -1,8 +1,10 @@
 <template>
-  <div class="breadcrumb component wrap-outer-breadcrumb layout-band">
+  <div class="wrap-outer-breadcrumb layout-band">
     <div class="wrap-breadcrumb" role="navigation" aria-label="breadcrumbs">
       <div class="breadcrumbs">
-        <a href="https://libraries.mit.edu" title="MIT Libraries">{{ msg }}</a>
+        <span v-for="link in trail" v-bind:key="link.url">
+          <a :href="link.url">{{ link.text }}</a>
+        </span>
       </div>
     </div>
   </div>
@@ -11,15 +13,53 @@
 <script>
 export default {
   name: "Breadcrumb",
-  props: {
-    msg: String
+  created() {
+    this.reset();
+  },
+  data() {
+    return {
+      trail: []
+    };
+  },
+  methods: {
+    add: function(link) {
+      this.trail.push({
+        text: link.text,
+        url: link.url
+      });
+    },
+    reset: function() {
+      this.trail = [
+        {
+          text: "Libraries home",
+          url: "https://libraries.mit.edu/"
+        },
+        {
+          text: "Search",
+          url: "/"
+        }
+      ];
+    }
   }
 };
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
-<style scoped>
-.breadcrumb {
-  border-color: red;
+<style scoped lang="scss">
+.breadcrumbs {
+  span {
+    margin-right: 0.5rem;
+
+    a {
+      margin-right: 0.5rem;
+    }
+  }
+  span:after {
+    content: "\00BB";
+  }
+
+  span:last-child:after {
+    content: "";
+  }
 }
 </style>

--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="facet component">
-    <p>{{ msg }}</p>
+    <p>{{ facetTitle }}</p>
   </div>
 </template>
 
@@ -8,7 +8,12 @@
 export default {
   name: "Facet",
   props: {
-    msg: String
+    facet: String
+  },
+  computed: {
+    facetTitle: function() {
+      return this.facet + " facet";
+    }
   }
 };
 </script>

--- a/src/components/Help.vue
+++ b/src/components/Help.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="help component gridband">
     <div class="inline-action well">
-      <div class="message">{{ msg }}</div>
+      <div class="message">{{ modelValue }}</div>
       <div class="actions">
         <a class="btn button-primary" href="https://libraries.mit.edu/ask/"
           >Ask Us</a
@@ -15,7 +15,7 @@
 export default {
   name: "Help",
   props: {
-    msg: String
+    modelValue: String
   }
 };
 </script>

--- a/src/components/Record.vue
+++ b/src/components/Record.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="record component">
-    <p>{{ msg }}</p>
+    <p>{{ modelValue }}</p>
     <ItemStatus msg="Item status field" />
     <Button msg="Button" />
     <Button msg="Button" />
@@ -19,7 +19,7 @@ export default {
     ItemStatus
   },
   props: {
-    msg: String
+    modelValue: String
   }
 };
 </script>

--- a/src/components/Related.vue
+++ b/src/components/Related.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="related component">
-    <p>{{ msg }}</p>
+    <p>{{ panelTitle }}</p>
   </div>
 </template>
 
@@ -8,7 +8,12 @@
 export default {
   name: "Related",
   props: {
-    msg: String
+    related: String
+  },
+  computed: {
+    panelTitle: function() {
+      return "Related " + this.related;
+    }
   }
 };
 </script>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -17,16 +17,11 @@
           Search
         </button>
       </div>
-      <pre>Raw query: _{{ query }}_</pre>
-      <pre>Parsed query: _{{ newSearchQuery }}_</pre>
     </form>
-    <SearchMetadata msg="This is the search metadata." />
   </div>
 </template>
 
 <script>
-import SearchMetadata from "./SearchMetadata.vue";
-
 export default {
   name: "Search Form",
   data() {
@@ -53,9 +48,6 @@ export default {
       }
       return newQuery;
     }
-  },
-  components: {
-    SearchMetadata
   }
 };
 </script>

--- a/src/components/SearchMetadata.vue
+++ b/src/components/SearchMetadata.vue
@@ -1,6 +1,8 @@
 <template>
-  <div class="searchmetadata component">
-    <p>{{ msg }}</p>
+  <div v-bind:class="panelStatus" class="panel">
+    <div class="panel-heading">{{ panelHeading }}</div>
+    <div class="panel-body">"{{ query }}"</div>
+    <div class="panel-footer">{{ status }}</div>
   </div>
 </template>
 
@@ -8,13 +10,27 @@
 export default {
   name: "SearchMetadata",
   props: {
-    msg: String
+    hits: Number,
+    query: String,
+    status: Object
+  },
+  computed: {
+    panelHeading: function() {
+      if (this.status.ready == true) {
+        return "Results summary: " + this.hits + " results";
+      } else if (this.status.loading == true) {
+        return "Loading results...";
+      }
+      return "Search Metadata:";
+    },
+    panelStatus: function() {
+      if (this.status.ready == true) {
+        return "panel-success";
+      }
+      return "panel-info";
+    }
   }
 };
 </script>
 
-<style scoped>
-.searchmetadata {
-  border-color: yellow;
-}
-</style>
+<style scoped></style>

--- a/tests/unit/about.spec.js
+++ b/tests/unit/about.spec.js
@@ -2,11 +2,11 @@ import { shallowMount } from "@vue/test-utils";
 import About from "@/components/About.vue";
 
 describe("About.vue", () => {
-  it("renders props.msg when passed", () => {
-    const msg = "new message";
+  it("renders data.about when passed", () => {
+    const about = "new message";
     const wrapper = shallowMount(About, {
-      props: { msg }
+      props: { modelValue: about }
     });
-    expect(wrapper.text()).toMatch(msg);
+    expect(wrapper.text()).toMatch(about);
   });
 });

--- a/tests/unit/breadcrumb.spec.js
+++ b/tests/unit/breadcrumb.spec.js
@@ -2,11 +2,10 @@ import { shallowMount } from "@vue/test-utils";
 import Breadcrumb from "@/components/Breadcrumb.vue";
 
 describe("Breadcrumb.vue", () => {
-  it("renders props.msg when passed", () => {
-    const msg = "new message";
-    const wrapper = shallowMount(Breadcrumb, {
-      props: { msg }
-    });
-    expect(wrapper.text()).toMatch(msg);
+  var wrapper = shallowMount(Breadcrumb, {});
+  it("starts with two links", () => {
+    expect(wrapper.text()).toMatch("Libraries home");
+    expect(wrapper.text()).toMatch("Search");
   });
+  // Need to write tests for manipulating the breadcrumb
 });

--- a/tests/unit/facet.spec.js
+++ b/tests/unit/facet.spec.js
@@ -2,11 +2,11 @@ import { shallowMount } from "@vue/test-utils";
 import Facet from "@/components/Facet.vue";
 
 describe("Facet.vue", () => {
-  it("renders props.msg when passed", () => {
-    const msg = "new message";
+  it("renders props.facet when passed", () => {
+    const facet = "new message";
     const wrapper = shallowMount(Facet, {
-      props: { msg }
+      props: { facet }
     });
-    expect(wrapper.text()).toMatch(msg);
+    expect(wrapper.text()).toMatch(facet);
   });
 });

--- a/tests/unit/help.spec.js
+++ b/tests/unit/help.spec.js
@@ -2,11 +2,11 @@ import { shallowMount } from "@vue/test-utils";
 import Help from "@/components/Help.vue";
 
 describe("Help.vue", () => {
-  it("renders props.msg when passed", () => {
-    const msg = "new message";
+  it("renders data.help when passed", () => {
+    const help = "new message";
     const wrapper = shallowMount(Help, {
-      props: { msg }
+      propsData: { modelValue: help }
     });
-    expect(wrapper.text()).toMatch(msg);
+    expect(wrapper.text()).toMatch(help);
   });
 });

--- a/tests/unit/record.spec.js
+++ b/tests/unit/record.spec.js
@@ -2,11 +2,11 @@ import { shallowMount } from "@vue/test-utils";
 import Record from "@/components/Record.vue";
 
 describe("Record.vue", () => {
-  it("renders props.msg when passed", () => {
-    const msg = "new message";
+  it("renders data.record when passed", () => {
+    const record = "new message";
     const wrapper = shallowMount(Record, {
-      props: { msg }
+      props: { modelValue: record }
     });
-    expect(wrapper.text()).toMatch(msg);
+    expect(wrapper.text()).toMatch(record);
   });
 });

--- a/tests/unit/related.spec.js
+++ b/tests/unit/related.spec.js
@@ -3,10 +3,10 @@ import Related from "@/components/Related.vue";
 
 describe("Related.vue", () => {
   it("renders props.msg when passed", () => {
-    const msg = "new message";
+    const related = "new message";
     const wrapper = shallowMount(Related, {
-      props: { msg }
+      props: { related }
     });
-    expect(wrapper.text()).toMatch(msg);
+    expect(wrapper.text()).toMatch(related);
   });
 });

--- a/tests/unit/searchmetadata.spec.js
+++ b/tests/unit/searchmetadata.spec.js
@@ -2,11 +2,29 @@ import { shallowMount } from "@vue/test-utils";
 import SearchMetadata from "@/components/SearchMetadata.vue";
 
 describe("SearchMetadata.vue", () => {
-  it("renders props.msg when passed", () => {
-    const msg = "new message";
+  it("reports search string and hit counts after a search", () => {
+    const hits = 6021023;
+    const query = "new message";
+    const status = {
+      errored: false,
+      ready: true
+    };
     const wrapper = shallowMount(SearchMetadata, {
-      props: { msg }
+      props: { hits, query, status }
     });
-    expect(wrapper.text()).toMatch(msg);
+    expect(wrapper.text()).toMatch("Results summary:");
+    expect(wrapper.text()).toMatch(query);
+    expect(wrapper.text()).toMatch(String(hits));
+  });
+  it("reports an interim message while waiting", () => {
+    const hits = 0;
+    const query = "foo";
+    const status = {
+      loading: true
+    };
+    const waiting = shallowMount(SearchMetadata, {
+      props: { hits, query, status }
+    });
+    expect(waiting.text()).toMatch("Loading results...");
   });
 });


### PR DESCRIPTION
This turns off any top-level component that is not needed for basic functioning of the app. It also makes a few components a bit more "real", such as the breadcrumbs and search metadata.

Part of achieving this work is to expand the amount of data defined by the application, and then hang conditional checks off those data structures.

#### How can a reviewer manually see the effects of these changes?

You can run this branch locally, or there are links to the review apps in-thread.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-81

#### Screenshots (if appropriate)
Initial rendering
![Screen Shot 2020-10-28 at 2 44 24 PM](https://user-images.githubusercontent.com/1403248/97482215-41e95c00-192c-11eb-8330-ef194c298d3e.png)

Returned results
![Screen Shot 2020-10-28 at 2 44 43 PM](https://user-images.githubusercontent.com/1403248/97482231-49a90080-192c-11eb-8fc4-f456e050b3d8.png)

#### Todo:
- [x] Tests

#### Includes new or updated dependencies?
NO
