### PR TITLE
Simplifies display of Item component in results

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -6,7 +6,7 @@
       }}</router-link>
     </h3>
     <p>{{ result.content_type }} | {{ result.publication_date }}</p>
-    <ul>
+    <ul class="list-inline-pipe contributors">
       <li
         v-for="contributor in result.contributors"
         v-bind:key="contributor.value"
@@ -14,21 +14,15 @@
         {{ contributor.value }} ({{ contributor.kind }})
       </li>
     </ul>
-    <div class="panel">
-      <div class="panel-heading">API data</div>
-      <div class="panel-body">
-        <pre>
-          {{ result }}
-        </pre>
-      </div>
-      <div class="panel-footer">
-        <a :href="result.source_link">View in Aleph</a>
-      </div>
-    </div>
+    <ul class="list-unbulleted copy-sup">
+      <li v-for="subject in result.subjects" v-bind:key="subject">
+        {{ subject }}
+      </li>
+    </ul>
+    <p><a :href="result.source_link">View in Aleph</a></p>
 
-    <ItemStatus msg="Item status field" />
-    <Button msg="Button" />
-    <Button msg="Button" />
+    <ItemStatus v-if="showStatus" msg="Item status field" />
+    <Button v-for="button in buttons" v-bind:key="button" msg="Button" />
   </div>
 </template>
 
@@ -44,6 +38,16 @@ export default {
   },
   props: {
     result: Object
+  },
+  computed: {
+    buttons: function() {
+      return [];
+    },
+    showStatus: function() {
+      return this.result.realtime_holdings_link == "Not Yet Implemented"
+        ? false
+        : true;
+    }
   }
 };
 </script>
@@ -54,8 +58,15 @@ export default {
   margin-bottom: 1rem;
   padding-bottom: 1rem;
 
-  .panel-body pre {
-    font-size: 12px;
+  .list-inline-pipe.contributors {
+    li:after {
+      margin-left: 0;
+      content: "; ";
+    }
+
+    li:last-child:after {
+      content: "";
+    }
   }
 }
 </style>

--- a/tests/unit/item.spec.js
+++ b/tests/unit/item.spec.js
@@ -2,7 +2,7 @@ import { shallowMount } from "@vue/test-utils";
 import Item from "@/components/Item.vue";
 
 describe("Item.vue", () => {
-  it("renders props.result.title when passed", () => {
+  it("renders all fields when present", () => {
     const result = {
       title: "The great American novel",
       content_type: "Book",
@@ -13,7 +13,8 @@ describe("Item.vue", () => {
         }
       ],
       publication_date: "1868",
-      source_link: "http://library.mit.edu/item/000544411"
+      source_link: "http://library.mit.edu/item/000544411",
+      subjects: ["fiction"]
     };
     const wrapper = shallowMount(Item, {
       props: { result }
@@ -22,6 +23,7 @@ describe("Item.vue", () => {
     expect(wrapper.text()).toMatch(result.content_type);
     expect(wrapper.text()).toMatch(result.contributors[0].value);
     expect(wrapper.text()).toMatch(result.publication_date);
-    expect(wrapper.text()).toMatch(result.source_link);
+    expect(wrapper.html()).toMatch(result.source_link);
+    expect(wrapper.text()).toMatch(result.subjects[0]);
   });
 });


### PR DESCRIPTION
This removes some of the not-ready components and displays from the rendering, to allow stakeholders to get a more accurate impression of what the final app will look like.

#### How can a reviewer manually see the effects of these changes?

Everything should run locally, or you can find the review app in-thread

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-142

#### Todo:
- [x] Tests

#### Includes new or updated dependencies?
NO
