### PR TITLE
Stubs router-view

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+VUE_APP_TIMDEX_API=https://timdex.example.com/api/v1

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+.env.development

--- a/tests/unit/app.spec.js
+++ b/tests/unit/app.spec.js
@@ -1,22 +1,5 @@
-import { mount } from "@vue/test-utils";
-import App from "@/App.vue";
-
 describe("App.vue", () => {
-  it("has internal data", () => {
-    expect(typeof App.data).toBe("function");
-    // Do we need to test for specific data structures?
-  });
-  it("stores a search string when doSearch is called", () => {
-    const wrapper = mount(App);
-    wrapper.vm.doSearch("");
-    expect(wrapper.vm.query).toBe("");
-    wrapper.vm.doSearch("apples");
-    expect(wrapper.vm.query).toBe("apples");
-  });
-  it("handles errors", () => {
-    const wrapper = mount(App);
-    expect(wrapper.vm.status.errored).toBe(false);
-    wrapper.vm.searchTimdex("");
-    // Not sure how to test async API calls that should produce errors
+  it("this is being refactored", () => {
+    console.log("TODO: https://mitlibraries.atlassian.net/browse/DISCO-144");
   });
 });

--- a/tests/unit/item.spec.js
+++ b/tests/unit/item.spec.js
@@ -1,8 +1,17 @@
-import { shallowMount } from "@vue/test-utils";
+import { mount, RouterLinkStub } from "@vue/test-utils";
 import Item from "@/components/Item.vue";
 
 describe("Item.vue", () => {
-  it("renders all fields when present", () => {
+  it("renders props.result.title when passed", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
     const result = {
       title: "The great American novel",
       content_type: "Book",
@@ -16,7 +25,13 @@ describe("Item.vue", () => {
       source_link: "http://library.mit.edu/item/000544411",
       subjects: ["fiction"]
     };
-    const wrapper = shallowMount(Item, {
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
       props: { result }
     });
     expect(wrapper.text()).toMatch(result.title);

--- a/tests/unit/record.spec.js
+++ b/tests/unit/record.spec.js
@@ -1,5 +1,5 @@
 describe("Record.vue", () => {
   it("renders title from result data", () => {
-    console.log("TODO");
+    console.log("TODO: https://mitlibraries.atlassian.net/browse/DISCO-152");
   });
 });

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  configureWebpack: {
+    devtool: "source-map"
+  }
+};


### PR DESCRIPTION
- Some of our unit tests needed a stubbed router-view. This provides that.
- adds `source-map` to development mode for better links to the correct line in the source in stack traces
- sets essential test config via in `.env.test`
- removes `app.vue` tests as that part of the app is being refactored and the tests were unintentionally calling real instances of timdex. 

#### How can a reviewer manually see the effects of these changes?

Check the CI or local results of `yarn test:unit` and confirm it is less noisy than on the main branch

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-149

#### Todo:
- [ ] Tests
- [ ] Documentation
- [x] Open ticket explaining need for tests on App.vue (via refactor to Results route testing ticket)
- [x] Open ticket explaining need for tests on Record.vue

#### Includes new or updated dependencies?
NO
