### PR TITLE
Introduce clearer developer and reviewer roles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,28 @@
-
-
 #### How can a reviewer manually see the effects of these changes?
 
-#### What are the relevant tickets?
+#### Relevant tickets
+
 - https://mitlibraries.atlassian.net/browse/DISCO-
 
-#### Screenshots (if appropriate)
+#### Developer
 
-#### Todo:
-- [ ] Tests
-- [ ] Documentation
-- [ ] Stakeholder approval
-- [ ] All new ENV documented in README
-- [ ] All new ENV added to Heroku Pipeline, Staging and Prod
+- [ ] All new ENV is documented in README
+- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
+- [ ] ANDI or Wave has been run in accordance to
+      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
+      all issues introduced by these changes have been resolved or opened as new
+      issues (link to those issues in the Pull Request details above)
+- [ ] Stakeholder approval has been confirmed (or is not needed)
 
-#### Includes new or updated dependencies?
+#### Code Reviewer
+
+- [ ] The commit message is clear and follows our guidelines
+      (not just this pull request message)
+- [ ] There are appropriate tests covering any new functionality
+- [ ] The documentation has been updated or is unnecessary
+- [ ] The changes have been verified
+- [ ] New dependencies are appropriate or there were no changes
+
+#### Includes new or updated dependencies
+
 YES | NO


### PR DESCRIPTION
Why are these changes being introduced:

* reminding developers of what should be done as part of opening a pull
  request beyond writing code and tests will allow reviewers to focus
  on the role they serve
* clarifying expectations for reviewers what they should check in
  addition to reading and understanding the code will ensure we are not
  missing important steps in the process of creating functional and
  sustainable code

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/DISCO-75

How does this address that need:

* This modifies the PULL_REQUEST_TEMPLATE we already had in place to
  provide checklists for both developers and reviewers with the intent
  that both sets of checklists should be completed before the code is
  merged

Are there side effects to this change:

No


#### How can a reviewer manually see the effects of these changes?

This pull request has manually been modified to use the new template.

#### Relevant tickets

- https://mitlibraries.atlassian.net/browse/DISCO-75

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO