### PR TITLE
DISCO-145 Add a route and component for 404 errors

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from "vue-router";
 import Record from "@/views/Record.vue";
 import Results from "@/views/Results.vue";
+import NotFound from "@/views/NotFound.vue";
 
 const routes = [
   {
@@ -20,6 +21,11 @@ const routes = [
     name: "Results",
     component: Results,
     props: route => ({ rawQuery: route.query.q })
+  },
+  {
+    path: "/:pathMatch(.*)*",
+    name: "NotFound",
+    component: NotFound
   }
 ];
 

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="wrap-outer-content layout-band">
+    <div class="wrap-content">
+      <main id="content-main" class="content-main" role="main">
+        <h2 class="title title-page">
+          Oops! The requested page was not found.
+        </h2>
+
+        <p>
+          <a href="/">Starting over</a> may help. If it does not, please
+          <a href="https://libraries.mit.edu/ask/">let us know</a>!
+        </p>
+      </main>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "NotFound"
+};
+</script>

--- a/tests/unit/notfound.spec.js
+++ b/tests/unit/notfound.spec.js
@@ -1,0 +1,30 @@
+import { mount } from "@vue/test-utils";
+import NotFound from "@/views/NotFound";
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("NotFound.vue", () => {
+  it("displays custom 404 page", async () => {
+    const mockRoute = {
+      params: {
+        name: "flerb"
+      }
+    };
+    const mockRouter = {
+      push: jest.fn()
+    };
+
+    const wrapper = mount(NotFound, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter
+        }
+      }
+    });
+
+    expect(wrapper.text()).toMatch("Oops! The requested page was not found.");
+  });
+});


### PR DESCRIPTION
This creates a catch-all route, such that any request resulting
in a 404 error will render a custom view (NotFound.vue) that lets
the user know that page doesn't exist and directs them back to
the root route.

#### How can a reviewer manually see the effects of these changes?
In the review app, try requesting a route that doesn't exist. You 
should see a custom error page similar to the one in Bento.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/DISCO-145

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval
- [x] All new ENV documented in README
- [x] All new ENV added to Heroku Pipeline, Staging and Prod

#### Includes new or updated dependencies?
NO
