### PR TITLE
Add initial unit tests for Results.vue

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,7 +20,7 @@ const routes = [
     path: "/results",
     name: "Results",
     component: Results,
-    props: route => ({ rawQuery: route.query.q })
+    props: true
   },
   {
     path: "/:pathMatch(.*)*",

--- a/tests/unit/results.spec.js
+++ b/tests/unit/results.spec.js
@@ -1,5 +1,208 @@
-describe("Resuls.vue", () => {
-  it("tests for various things...", () => {
-    console.log("TODO: https://mitlibraries.atlassian.net/browse/DISCO-153");
+import { mount, RouterLinkStub } from "@vue/test-utils";
+import axios from "axios";
+import Results from "@/views/Results.vue";
+
+var mockResponse = {};
+
+jest.mock("axios");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Results.vue", () => {
+  it("returns no results", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        hits: 0,
+        results: []
+      }
+    };
+
+    axios.get.mockImplementation(() => Promise.resolve(mockResponse));
+
+    const mockRoute = {
+      query: { q: "obscura" }
+    };
+    const mockRouter = {
+      push: jest.fn()
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter
+        }
+      }
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/search?q=obscura"
+    );
+
+    expect(wrapper.vm.$data.status.loading).toBe(true);
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.vm.$data.hits).toBe(0);
+      expect(wrapper.vm.$data.results.length).toBe(0);
+    });
+  });
+
+  it("loads a single record", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        hits: 1,
+        results: [
+          {
+            id: "002574584",
+            title: "Cheese",
+            source: "MIT Aleph"
+          }
+        ]
+      }
+    };
+
+    axios.get.mockImplementation(() => Promise.resolve(mockResponse));
+
+    const mockRoute = {
+      query: { q: "cheese" }
+    };
+    const mockRouter = {
+      push: jest.fn()
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter
+        }
+      }
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/search?q=cheese"
+    );
+
+    expect(wrapper.vm.$data.status.loading).toBe(true);
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.vm.$data.hits).toBe(1);
+      expect(wrapper.text()).toMatch("Cheese");
+      expect(wrapper.vm.$data.results[0].id).toBe("002574584");
+      expect(wrapper.vm.$data.results[0].title).toBe("Cheese");
+    });
+  });
+
+  it("loads multiple records", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        hits: 2,
+        results: [
+          {
+            id: "002574584",
+            title: "Cheese",
+            source: "MIT Aleph"
+          },
+          {
+            id: "002574585",
+            title: "Fromage",
+            source: "MIT Aleph"
+          }
+        ]
+      }
+    };
+
+    axios.get.mockImplementation(() => Promise.resolve(mockResponse));
+
+    const mockRoute = {
+      query: { q: "cheese" }
+    };
+    const mockRouter = {
+      push: jest.fn()
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter
+        }
+      }
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/search?q=cheese"
+    );
+
+    expect(wrapper.vm.$data.status.loading).toBe(true);
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.vm.$data.hits).toBe(2);
+      expect(wrapper.text()).toMatch("Cheese");
+      expect(wrapper.text()).toMatch("Fromage");
+      expect(wrapper.vm.$data.results[0].id).toBe("002574584");
+      expect(wrapper.vm.$data.results[0].title).toBe("Cheese");
+      expect(wrapper.vm.$data.results[1].id).toBe("002574585");
+      expect(wrapper.vm.$data.results[1].title).toBe("Fromage");
+    });
+  });
+
+  it("catches errors", async () => {
+    mockResponse = {
+      status: 500,
+      data: {
+        error: "Now you've done it"
+      }
+    };
+
+    axios.get.mockImplementation(() => Promise.reject(mockResponse));
+
+    const mockRoute = {
+      query: { q: "snow crash" }
+    };
+    const mockRouter = {
+      push: jest.fn()
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter
+        }
+      }
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/search?q=snow crash"
+    );
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.text()).toMatch("Something went wrong");
+      expect(wrapper.text()).toMatch("Starting over may help");
+    });
   });
 });


### PR DESCRIPTION
Why these changes are being introduced:
This backfills testing for the Results component. We had delayed
testing this component until we had a better handle on vue-test-utils,
and specifically how to mock API calls and routes.

Relevant ticket(s):
https://mitlibraries.atlassian.net/browse/DISCO-153

How this addresses that need:
This adds a few rudimentary unit tests for the Record component, using
mocked axios responses and mocked routes. The approach is similar to
our initial rests for the Record component.

Side effects to this change:
* The searchTimdex method is now async
* We no longer use function mode to pass the query param as a prop, as
it was unclear how to mock this in the tests

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
