### PR TITLE
Updates default branch from `master` to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Why these changes are being introduced:
The term `master` recalls the intergenerational trauma of
slavery, and its use conflicts with MIT Libraries' core values.

Relevant ticket(s):
N/A

How this addresses that need:
This updates GitHub Actions to watch the new default branch, `main`.

Side effects to this change:
* CI now watches `main`
* Heroku automatically deploys from `main`
* Those will local clones of this repo will need to pull `main`,
delete `master` locally, and begin branching off of `main` instead

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
