### PR TITLE
Expands unit tests for Item

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -6,49 +6,33 @@
       }}</router-link>
     </h3>
     <p>{{ result.content_type }} | {{ result.publication_date }}</p>
-    <ul class="list-inline-pipe contributors">
+    <ul v-if="result.contributors" class="list-inline-pipe contributors">
       <li
         v-for="contributor in result.contributors"
         v-bind:key="contributor.value"
       >
-        {{ contributor.value }} ({{ contributor.kind }})
+        {{ contributor.value }} ({{ contributor.kind || "contributor" }})
       </li>
     </ul>
-    <ul class="list-unbulleted copy-sup">
+    <ul v-if="result.subjects" class="list-unbulleted copy-sup">
       <li v-for="subject in result.subjects" v-bind:key="subject">
         {{ subject }}
       </li>
     </ul>
-    <p><a :href="result.source_link">View in Aleph</a></p>
-
-    <ItemStatus v-if="showStatus" msg="Item status field" />
-    <Button v-for="button in buttons" v-bind:key="button" msg="Button" />
+    <p v-if="result.source_link">
+      <a :href="result.source_link">View in {{ result.source || "source" }}</a>
+    </p>
   </div>
 </template>
 
 <script>
-import Button from "./Button.vue";
-import ItemStatus from "./ItemStatus.vue";
-
 export default {
   name: "Item",
-  components: {
-    Button,
-    ItemStatus
-  },
+  components: {},
   props: {
     result: Object
   },
-  computed: {
-    buttons: function() {
-      return [];
-    },
-    showStatus: function() {
-      return this.result.realtime_holdings_link == "Not Yet Implemented"
-        ? false
-        : true;
-    }
-  }
+  computed: {}
 };
 </script>
 

--- a/tests/unit/item.spec.js
+++ b/tests/unit/item.spec.js
@@ -41,4 +41,204 @@ describe("Item.vue", () => {
     expect(wrapper.html()).toMatch(result.source_link);
     expect(wrapper.text()).toMatch(result.subjects[0]);
   });
+
+  it("does not error when non-required elements are missing", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
+    const result = {
+      title: "The great American novel"
+    };
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
+      props: { result }
+    });
+    expect(wrapper.html()).toMatch(result.title);
+  });
+
+  it("does not show link to source if not provided", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
+    const result = {};
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
+      props: { result }
+    });
+    expect(wrapper.text()).not.toMatch("View in");
+  });
+
+  it("uses source if present for link", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
+    const result = {
+      title: "The great American novel",
+      source_link: "http://library.mit.edu/item/000544411",
+      source: "Super cool source"
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
+      props: { result }
+    });
+    expect(wrapper.text()).toMatch("View in Super cool source");
+    expect(wrapper.html()).toMatch(result.source_link);
+  });
+
+  it("uses generic source if not present for link", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
+    const result = {
+      title: "The great American novel",
+      source_link: "http://library.mit.edu/item/000544411"
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
+      props: { result }
+    });
+    expect(wrapper.text()).toMatch("View in source");
+    expect(wrapper.html()).toMatch(result.source_link);
+  });
+
+  it("displays subjects if present", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
+    const result = {
+      title: "The great American novel",
+      source_link: "http://library.mit.edu/item/000544411",
+      subjects: ["Things made of cheese", "Wisconsin -- History -- Cheese"]
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
+      props: { result }
+    });
+    expect(wrapper.text()).toMatch("Things made of cheese");
+    expect(wrapper.text()).toMatch("Wisconsin -- History -- Cheese");
+  });
+
+  it("displays authors if present", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
+    const result = {
+      title: "The great American novel",
+      source_link: "http://library.mit.edu/item/000544411",
+      contributors: [
+        { value: "Lastoson, Firsty", kind: "Creator" },
+        { value: "Namenamenamename", kind: "Assistant to the Regional Manager" }
+      ]
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
+      props: { result }
+    });
+    expect(wrapper.text()).toMatch("Lastoson, Firsty (Creator)");
+    expect(wrapper.text()).toMatch(
+      "Namenamenamename (Assistant to the Regional Manager)"
+    );
+  });
+
+  it("displays authors generic kind if not provided", () => {
+    const $router = {
+      push: jest.fn()
+    };
+    const $route = {
+      params: {
+        recordId: "000544411"
+      }
+    };
+
+    const result = {
+      title: "The great American novel",
+      source_link: "http://library.mit.edu/item/000544411",
+      contributors: [
+        { value: "Lastoson, Firsty", kind: "Creator" },
+        { value: "Namenamenamename" }
+      ]
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub
+        },
+        mocks: { $route, $router }
+      },
+      props: { result }
+    });
+    expect(wrapper.text()).toMatch("Lastoson, Firsty (Creator)");
+    expect(wrapper.text()).toMatch("Namenamenamename (contributor)");
+  });
 });


### PR DESCRIPTION
#### Why are these changes being introduced:

* some of the initial work on Item was completed before we had a good
  testing strategy worked out with the understanding we'll loop back and
  back fill the tests when we could

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/DISCO-154

#### How does this address that need:

* Adds additional unit tests
* Provides some additional `v-if` statements to ensure we don't display
  empty html elements when an array is empty
* Updates UI to more accurately reflect the multiple sources that are
  contained in TIMDEX

#### Document any side effects to this change:

* I've removed the Button and ItemStatus components as they are not
  currently being used and in the current state just make the code more
  complicated. As such, we'll need to add them back in once we add true
  functionality to them in future sprints.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
