### PR TITLE
DISCO-187 Add friendly message when no results are found

### DIFF
--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -14,6 +14,9 @@
       <Facet v-for="facet in facets" v-bind:facet="facet" v-bind:key="facet" />
     </div>
     <div v-bind:class="contentClass">
+      <div v-if="hits == 0">
+        <p>Sorry, no results found for {{ query }}.</p>
+      </div>
       <Item
         v-for="(result, index) in results"
         v-bind:result="result"
@@ -42,7 +45,7 @@ export default {
   data() {
     return {
       facets: [],
-      hits: 0,
+      hits: null,
       results: [],
       results_per_page: process.env.VUE_APP_RESULTS_PER_PAGE || 5,
       status: {

--- a/tests/unit/results.spec.js
+++ b/tests/unit/results.spec.js
@@ -11,7 +11,7 @@ afterEach(() => {
 });
 
 describe("Results.vue", () => {
-  it("returns no results", async () => {
+  it("returns no results with friendly message", async () => {
     mockResponse = {
       status: 200,
       data: {
@@ -50,6 +50,7 @@ describe("Results.vue", () => {
       expect(wrapper.vm.$data.status.loading).toBe(false);
       expect(wrapper.vm.$data.hits).toBe(0);
       expect(wrapper.vm.$data.results.length).toBe(0);
+      expect(wrapper.text()).toMatch("Sorry, no results found for obscura.");
     });
   });
 


### PR DESCRIPTION
#### Why these changes are being introduced:

There is currently no feedback when a search returns no results.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/DISCO-187

#### How this addresses that need:

This adds a message letting the user know their search didn't yield
any results.

#### Side effects of this change:

N/A

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
