### PR TITLE
Adds pagination to Results list 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ This repository will focus on the `DISCO UI` portion of this work.
 ## Environment variables
 
 ### Required
+
 `VUE_APP_TIMDEX_API`: the root URL for the TIMDEX API
 
 ### Optional
-`VUE_APP_RESULTS_PER_PAGE`: the number of records displayed per page
+
 `VUE_APP_SENTRY_DSN`: set to Sentry project key to log exceptions
 
 ## Project setup

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,7 +62,6 @@ export default {
       hits: 0,
       query: "",
       record: undefined,
-      results_per_page: process.env.VUE_APP_RESULTS_PER_PAGE || 5,
       relateds: [],
       results: [],
       status: {
@@ -76,7 +75,7 @@ export default {
   methods: {
     receiveSearch: function (query) {
       this.query = query;
-      this.$router.push({ name: "Results", query: { q: this.query } });
+      this.$router.push({ name: "Results", query: { q: this.query, page: 1 } });
     },
     receiveSummary: function (data) {
       this.hits = data.hits;
@@ -115,8 +114,4 @@ export default {
 <style>
 @import "./assets/css/bento.min.css";
 @import "./assets/css/libraries-main.min.css";
-
-.component {
-  border: 0.4rem solid black;
-}
 </style>

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -1,20 +1,78 @@
 <template>
-  <div class="pagination component">
-    <p>{{ msg }}</p>
-  </div>
+  <nav class="pagination component">
+    <p v-if="onlyPage() && this.hits > 0">Viewing all results</p>
+
+    <span v-if="firstPage()">
+      <button id="firstPage" @click="changeUrlQuery('page', firstPage())">
+        « First
+      </button>
+    </span>
+
+    <span v-if="prevPage()" class="page">
+      <button
+        id="prevPage"
+        rel="previous"
+        @click="changeUrlQuery('page', prevPage())"
+      >
+        ‹ Previous
+      </button>
+    </span>
+
+    <span v-if="nextPage()" class="page">
+      <button
+        id="nextPage"
+        rel="next"
+        @click="changeUrlQuery('page', nextPage())"
+      >
+        Next ›
+      </button>
+    </span>
+  </nav>
 </template>
 
 <script>
 export default {
   name: "Pagination",
   props: {
-    msg: String,
+    hits: Number,
+    page: String,
+    per_page: Number,
+  },
+  methods: {
+    pageNum() {
+      return parseInt(this.$route.query.page);
+    },
+    onlyPage() {
+      if (this.hits <= this.per_page) {
+        return true;
+      }
+    },
+    firstPage() {
+      if (this.pageNum() > 2) {
+        return 1;
+      }
+    },
+    nextPage() {
+      if (this.pageNum() * this.per_page < this.hits) {
+        return this.pageNum() + 1;
+      }
+    },
+    prevPage() {
+      if (this.pageNum() != 1) {
+        return this.pageNum() - 1;
+      }
+    },
+    changeUrlQuery(paramName, changeTo) {
+      const newQuery = Object.assign({}, this.$route.query);
+
+      newQuery[paramName] = changeTo.toString();
+
+      this.$router.push({
+        query: newQuery,
+      });
+    },
   },
 };
 </script>
 
-<style scoped>
-.pagination {
-  border-color: teal;
-}
-</style>
+<style scoped></style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,6 +32,15 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes,
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition;
+    } else if (to.hash) {
+      return { el: to.hash, behavior: "smooth" };
+    } else {
+      return { top: 0, behavior: "smooth" };
+    }
+  },
 });
 
 export default router;

--- a/tests/unit/pagination.spec.js
+++ b/tests/unit/pagination.spec.js
@@ -2,11 +2,236 @@ import { shallowMount } from "@vue/test-utils";
 import Pagination from "@/components/Pagination.vue";
 
 describe("Pagination.vue", () => {
-  it("renders props.msg when passed", () => {
-    const msg = "new message";
+  it("displays no pagination links when there are no hits", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
     const wrapper = shallowMount(Pagination, {
-      props: { msg },
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 0,
+        per_page: 20,
+      },
     });
-    expect(wrapper.text()).toMatch(msg);
+
+    expect(wrapper.text()).toMatch("");
+  });
+
+  it("displays message when viewing all results", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 5,
+        per_page: 20,
+      },
+    });
+
+    expect(wrapper.text()).toMatch("Viewing all results");
+  });
+
+  it("displays only next when on first page of results", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 25,
+        per_page: 20,
+      },
+    });
+
+    expect(wrapper.text()).toMatch("Next");
+    expect(wrapper.text()).not.toMatch("Previous");
+    expect(wrapper.text()).not.toMatch("First");
+  });
+
+  it("displays only next and previous when on second page", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "2" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 100,
+        per_page: 20,
+      },
+    });
+
+    expect(wrapper.text()).toMatch("Next");
+    expect(wrapper.text()).toMatch("Previous");
+    expect(wrapper.text()).not.toMatch("First");
+  });
+
+  it("displays next previous and first when on third page", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "3" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 100,
+        per_page: 20,
+      },
+    });
+
+    expect(wrapper.text()).toMatch("Next");
+    expect(wrapper.text()).toMatch("Previous");
+    expect(wrapper.text()).toMatch("First");
+  });
+
+  it("does not show next when on last page but shows previous and first", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "3" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 59,
+        per_page: 20,
+      },
+    });
+
+    expect(wrapper.text()).not.toMatch("Next");
+    expect(wrapper.text()).toMatch("Previous");
+    expect(wrapper.text()).toMatch("First");
+  });
+
+  it("goes to next page when next is clicked", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "3" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 100,
+        per_page: 20,
+      },
+    });
+
+    wrapper.find("button#nextPage").trigger("click");
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      query: { page: "4", q: "obscura" },
+    });
+  });
+
+  it("goes to previous page when previous is clicked", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "3" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 100,
+        per_page: 20,
+      },
+    });
+
+    wrapper.find("button#prevPage").trigger("click");
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      query: { page: "2", q: "obscura" },
+    });
+  });
+
+  it("goes to previous page when previous is clicked", () => {
+    const mockRoute = {
+      query: { q: "obscura", page: "3" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 100,
+        per_page: 20,
+      },
+    });
+
+    wrapper.find("button#firstPage").trigger("click");
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      query: { page: "1", q: "obscura" },
+    });
   });
 });

--- a/tests/unit/results.spec.js
+++ b/tests/unit/results.spec.js
@@ -197,7 +197,7 @@ describe("Results.vue", () => {
     expect(axios.get).toHaveBeenCalledTimes(1);
 
     expect(axios.get).toHaveBeenCalledWith(
-      "https://timdex.example.com/api/v1/search?q=snow crash"
+      "https://timdex.example.com/api/v1/search?q=snow%20crash"
     );
 
     await wrapper.vm.$nextTick(() => {


### PR DESCRIPTION
## Why are these changes being introduced:

* Allowing users to look at more than the first set of results is
  important

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/DISCO-40

## How does this address that need:

* This implements some basic logic to determine which pagination nav
  links are appropriate (next, previous, first, none)
* Each appropriate link will update the querystring and thus perform a
  new search

## Document any side effects to this change:

* Some web pagination systems allow arbitrary jumping through results.
  At this time, it was determined that doesn't make a lot of sense as
  our results are only ordered by relevance and jumping past "more"
  relevant results to get to "less" relevant results is not a use case
  that makes sense to support. However, if we provide other sort orders,
  it may make more sense to implment more logic in the pagination to
  provide jumps (i.e. if sorted by data, jump a bunch of pages to skip
  the ranges you aren't interested in... or if sorted alphabetically
  jump to the "P" set)


#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
