### PR TITLE
Moves SearchMetadata component from App to Results

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,23 +6,10 @@
       <div class="wrap-content">
         <div class="layout-band">
           <SearchForm @searched="receiveSearch" />
-          <SearchMetadata
-            v-if="showSearchMetadata"
-            v-model:query.lazy="query"
-            v-model:status="status"
-            v-model:hits="hits"
-          />
         </div>
         <div v-bind:class="layoutBand">
           <div v-bind:class="layoutContent">
             <router-view @results="receiveSummary" />
-          </div>
-          <div v-if="sidebarRight" class="col1q-r">
-            <Related
-              v-for="related in relateds"
-              v-bind:related="related"
-              v-bind:key="related"
-            />
           </div>
         </div>
         <Help v-if="help" v-model="help" />
@@ -39,9 +26,7 @@ import Breadcrumb from "./components/Breadcrumb.vue";
 import Footer from "./components/Footer.vue";
 import Header from "./components/Header.vue";
 import Help from "./components/Help.vue";
-import Related from "./components/Related.vue";
 import SearchForm from "./components/SearchForm.vue";
-import SearchMetadata from "./components/SearchMetadata.vue";
 
 export default {
   name: "App",
@@ -51,25 +36,15 @@ export default {
     Footer,
     Header,
     Help,
-    Related,
     SearchForm,
-    SearchMetadata,
   },
   data() {
     return {
-      about: undefined,
-      help: undefined,
       hits: 0,
       query: "",
-      record: undefined,
-      relateds: [],
-      results: [],
-      status: {
-        error_message: "",
-        errored: false,
-        loading: false,
-        ready: false,
-      },
+      help: "",
+      about: "",
+      sidebarRight: false,
     };
   },
   methods: {
@@ -94,18 +69,6 @@ export default {
         return "col3q";
       }
       return "";
-    },
-    showSearchMetadata: function () {
-      if (this.query === "") {
-        return false;
-      }
-      if (this.status.errored === true) {
-        return false;
-      }
-      return true;
-    },
-    sidebarRight: function () {
-      return this.relateds.length ? true : false;
     },
   },
 };

--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -35,12 +35,14 @@ export default {
   name: "Pagination",
   props: {
     hits: Number,
-    page: String,
     per_page: Number,
   },
   methods: {
     pageNum() {
-      return parseInt(this.$route.query.page);
+      if (this.$route.query.page) {
+        return parseInt(this.$route.query.page);
+      }
+      return 1;
     },
     onlyPage() {
       if (this.hits <= this.per_page) {

--- a/src/components/SearchMetadata.vue
+++ b/src/components/SearchMetadata.vue
@@ -1,8 +1,10 @@
 <template>
-  <div v-bind:class="panelStatus" class="panel">
-    <div class="panel-heading">{{ panelHeading }}</div>
-    <div class="panel-body">"{{ query }}"</div>
-    <div class="panel-footer">{{ status }}</div>
+  <div class="panel panel-info">
+    <div class="panel-heading">Search Results</div>
+    <div class="panel-body">Searched for: "{{ searchterm }}"</div>
+    <div v-if="hits > 0" class="panel-footer">
+      Viewing records {{ start() }} to {{ end() }} of {{ hits }}
+    </div>
   </div>
 </template>
 
@@ -11,23 +13,23 @@ export default {
   name: "SearchMetadata",
   props: {
     hits: Number,
-    query: String,
-    status: Object,
+    searchterm: String,
   },
-  computed: {
-    panelHeading: function () {
-      if (this.status.ready == true) {
-        return "Results summary: " + this.hits + " results";
-      } else if (this.status.loading == true) {
-        return "Loading results...";
+  methods: {
+    page() {
+      if (this.$route.query.page) {
+        return parseInt(this.$route.query.page);
       }
-      return "Search Metadata:";
+      return 1;
     },
-    panelStatus: function () {
-      if (this.status.ready == true) {
-        return "panel-success";
-      }
-      return "panel-info";
+    per_page() {
+      return 20;
+    },
+    start() {
+      return this.per_page() * (this.page() - 1) + 1;
+    },
+    end() {
+      return Math.min(this.page() * this.per_page(), this.hits);
     },
   },
 };

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -14,8 +14,9 @@
       <Facet v-for="facet in facets" v-bind:facet="facet" v-bind:key="facet" />
     </div>
     <div v-bind:class="contentClass" v-if="this.status.loading == false">
+      <SearchMetadata v-model:searchterm="searchterm" v-model:hits="hits" />
       <div v-if="hits == 0">
-        <p>Sorry, no results found for {{ query }}.</p>
+        <p>Sorry, no results found for {{ searchterm }}.</p>
       </div>
       <Item
         v-for="(result, index) in results"
@@ -23,7 +24,7 @@
         v-bind:index="index"
         v-bind:key="result.id"
       />
-      <Pagination :hits="hits" :page="page" :per_page="per_page" />
+      <Pagination :hits="hits" :per_page="per_page" />
     </div>
   </div>
 </template>
@@ -32,6 +33,7 @@
 import Facet from "@/components/Facet.vue";
 import Item from "@/components/Item.vue";
 import Pagination from "@/components/Pagination.vue";
+import SearchMetadata from "@/components/SearchMetadata.vue";
 var qs = require("qs");
 
 const axios = require("axios").default;
@@ -42,6 +44,7 @@ export default {
     Facet,
     Item,
     Pagination,
+    SearchMetadata,
   },
   data() {
     return {
@@ -64,9 +67,6 @@ export default {
     layoutClass: function () {
       return this.showSidebar ? "layout-1q3q" : "";
     },
-    showPagination: function () {
-      return this.hits > 0;
-    },
     showSidebar: function () {
       return this.facets.length ? true : false;
     },
@@ -74,6 +74,7 @@ export default {
   methods: {
     async searchTimdex() {
       this.status.loading = true;
+      this.searchterm = this.$route.query.q;
       try {
         let timdexURL = String(process.env.VUE_APP_TIMDEX_API) + "/search?";
         let query = qs.stringify(this.$route.query);
@@ -81,7 +82,6 @@ export default {
         this.results = response.data.results;
         this.hits = response.data.hits;
         this.status.loading = false;
-        this.query = this.$route.query.q;
       } catch (error) {
         this.status.errored = true;
         this.status.loading = false;

--- a/tests/unit/pagination.spec.js
+++ b/tests/unit/pagination.spec.js
@@ -234,4 +234,30 @@ describe("Pagination.vue", () => {
       query: { page: "1", q: "obscura" },
     });
   });
+
+  it("displays only next when on first page of results when page not set", () => {
+    const mockRoute = {
+      query: { q: "obscura" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Pagination, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        hits: 25,
+        per_page: 20,
+      },
+    });
+
+    expect(wrapper.text()).toMatch("Next");
+    expect(wrapper.text()).not.toMatch("Previous");
+    expect(wrapper.text()).not.toMatch("First");
+  });
 });

--- a/tests/unit/searchmetadata.spec.js
+++ b/tests/unit/searchmetadata.spec.js
@@ -3,28 +3,119 @@ import SearchMetadata from "@/components/SearchMetadata.vue";
 
 describe("SearchMetadata.vue", () => {
   it("reports search string and hit counts after a search", () => {
+    const mockRoute = {
+      query: { page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
     const hits = 6021023;
-    const query = "new message";
-    const status = {
-      errored: false,
-      ready: true,
-    };
+    const searchterm = "new message";
     const wrapper = shallowMount(SearchMetadata, {
-      props: { hits, query, status },
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: { hits, searchterm },
     });
-    expect(wrapper.text()).toMatch("Results summary:");
-    expect(wrapper.text()).toMatch(query);
+
+    expect(wrapper.text()).toMatch("Search Results");
+    expect(wrapper.text()).toMatch(searchterm);
     expect(wrapper.text()).toMatch(String(hits));
+    expect(wrapper.text()).toMatch("Viewing records 1 to 20 of " + hits);
   });
-  it("reports an interim message while waiting", () => {
-    const hits = 0;
-    const query = "foo";
-    const status = {
-      loading: true,
+
+  it("displays 21 to 40 on page 2", () => {
+    const mockRoute = {
+      query: { page: "2" },
     };
-    const waiting = shallowMount(SearchMetadata, {
-      props: { hits, query, status },
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const hits = 49;
+    const wrapper = shallowMount(SearchMetadata, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+
+      props: { hits },
     });
-    expect(waiting.text()).toMatch("Loading results...");
+
+    expect(wrapper.text()).toMatch("Viewing records 21 to 40 of " + hits);
+  });
+
+  it("displays 1 to 7 of 7", () => {
+    const mockRoute = {
+      query: { page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const hits = 7;
+    const wrapper = shallowMount(SearchMetadata, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+
+      props: { hits },
+    });
+
+    expect(wrapper.text()).toMatch("Viewing records 1 to 7 of " + hits);
+  });
+
+  it("displays 21 to 38 of 38", () => {
+    const mockRoute = {
+      query: { page: "2" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const hits = 38;
+    const wrapper = shallowMount(SearchMetadata, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+
+      props: { hits },
+    });
+
+    expect(wrapper.text()).toMatch("Viewing records 21 to 38 of " + hits);
+  });
+
+  it("displays 1 to 20 when no page is passed", () => {
+    const mockRoute = {
+      query: {},
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const hits = 38;
+    const wrapper = shallowMount(SearchMetadata, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+
+      props: { hits },
+    });
+    expect(wrapper.text()).toMatch("Viewing records 1 to 20 of " + hits);
   });
 });


### PR DESCRIPTION
## Why are these changes being introduced:

* The SearchMetadata is only used as part of the rendering logic for
  Results. As such, it is easier to work with it as a child Component
  rather than a sibling.

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/DISCO-195

## How does this address that need:

* This moves the SearchMetadata component to be a child of Results

## Document any side effects to this change:

* I've removed some additional data elements from App that I noticed
  were unused when moving the SearchMetadata component
* I've removed the Related component from App and did not add it any
  place else. I feel like it'll be part of Record, but until we decide
  for sure I'd prefer not to include it at all. I've left Help and About
  as those seem like App level components and will likely have clear
  purpose in the near future.
* I've included some pagination metadata that didn't land with the
  Pagination work as there wasn't a clear place to display it and I
  knew this work was upcoming.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
