### PR TITLE
DISCO-41 Implement faceting on Results list

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -1,25 +1,70 @@
 <template>
-  <div class="facet component">
-    <p>{{ facetTitle }}</p>
-  </div>
+  <dl v-if="facetList && facetList.length" class="facet">
+    <dt>{{ facetHeader }}</dt>
+    <dd v-for="(facet, index) in facetList" :key="index">
+      <input
+        type="checkbox"
+        :id="facetHeader + '_' + facet.name"
+        :value="facet.name"
+        v-model="checkedFacets"
+      />
+      <label :for="facetHeader + '_' + facet.name">
+        {{ facet.name }} {{ "(" + facet.count + ")" }}</label
+      >
+    </dd>
+  </dl>
 </template>
 
 <script>
 export default {
   name: "Facet",
-  props: {
-    facet: String,
+  data() {
+    return {
+      checkedFacets: [],
+    };
   },
-  computed: {
-    facetTitle: function () {
-      return this.facet + " facet";
+  props: {
+    facetList: Array,
+    facetHeader: String,
+  },
+  methods: {
+    applyFacets: function () {
+      let facetHeader = this.facetHeader;
+      let facetsToApply;
+
+      // facetsToApply needs to be a string for some facets and an array for
+      // others, or else the TIMDEX call will fail
+      if (
+        facetHeader == "content_type" ||
+        facetHeader == "literary_form" ||
+        facetHeader == "source"
+      ) {
+        facetsToApply = this.checkedFacets[0];
+      } else {
+        facetsToApply = this.checkedFacets;
+      }
+
+      // We need to copy the route query instead of assigning it to a variable
+      // for Vue reasons
+      const newQuery = Object.assign({}, this.$route.query);
+      newQuery["page"] = 1;
+
+      if (facetsToApply && facetsToApply.length) {
+        newQuery[facetHeader] = facetsToApply;
+      } else {
+        delete newQuery[facetHeader];
+      }
+
+      this.$router.push({ query: newQuery });
     },
+  },
+  mounted() {
+    this.$watch(
+      () => this.checkedFacets,
+      () => {
+        this.applyFacets();
+      }
+    );
   },
 };
 </script>
-
-<style scoped>
-.facet {
-  border-color: blue;
-}
-</style>

--- a/tests/unit/facet.spec.js
+++ b/tests/unit/facet.spec.js
@@ -2,11 +2,76 @@ import { shallowMount } from "@vue/test-utils";
 import Facet from "@/components/Facet.vue";
 
 describe("Facet.vue", () => {
-  it("renders props.facet when passed", () => {
-    const facet = "new message";
+  it("displays header and available facets in sidebar", () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
     const wrapper = shallowMount(Facet, {
-      props: { facet },
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [
+          { name: "english", count: 1 },
+          { name: "french", count: 2 },
+        ],
+        facetHeader: "language",
+      },
     });
-    expect(wrapper.text()).toMatch(facet);
+
+    wrapper.setData({ checkedFacets: ["english"] });
+
+    expect(wrapper.text()).toMatch("language");
+    expect(wrapper.text()).toMatch("english (1)");
+    expect(wrapper.text()).toMatch("french (2)");
+  });
+
+  it("hides facet list if no facets are available", () => {
+    const wrapper = shallowMount(Facet, {
+      props: {
+        facetList: [],
+        facetHeader: "language",
+      },
+    });
+
+    const dl = wrapper.find("dl");
+    expect(dl.exists()).toBe(false);
+  });
+
+  it("mutates v-model as expected when checkbox is clicked", async () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [{ name: "english", count: 1 }],
+        facetHeader: "language",
+      },
+    });
+
+    const checkbox = wrapper.find('input[type="checkbox"][value="english"]');
+
+    await checkbox.setValue(true);
+    expect(wrapper.vm.checkedFacets).toContain("english");
+
+    await checkbox.setValue(false);
+    expect(wrapper.vm.checkedFacets).toEqual([]);
   });
 });

--- a/tests/unit/results.spec.js
+++ b/tests/unit/results.spec.js
@@ -206,4 +206,47 @@ describe("Results.vue", () => {
       expect(wrapper.text()).toMatch("Starting over may help");
     });
   });
+
+  it("uses brackets syntax in query strings for TIMDEX", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        hits: 0,
+        results: [],
+      },
+    };
+
+    axios.get.mockImplementation(() => Promise.reject(mockResponse));
+
+    const mockRoute = {
+      query: {
+        q: "cheese",
+        language: "english",
+        contributor: ["cow", "goat"],
+        content_type: "text",
+      },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/search?q=cheese&language%5B%5D=english&contributor%5B%5D=cow&contributor%5B%5D=goat&content_type=text"
+    );
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
#### Why these changes are being introduced:

Facets are a high priority for the new discovery UI.

#### Relevant ticket(s):

* Closes: https://mitlibraries.atlassian.net/browse/DISCO-41
* Relates to: https://mitlibraries.atlassian.net/browse/DISCO-210

#### How this addresses that need:

This adds a v-model to the Facet component, such that whenever a checkbox for
a given facet is check or unchecked, that facet is added to or removed from the
v-model. The component watches the v-model, and when the data changes, it calls
a method that updates the URL params accordingly.

#### Side effects of this change:

* There are some minor changes to the Results component around how we construct
the query string, because TIMDEX uses the brackets syntax for arrays.
* Since input data isn't persisted, checked boxes reset when the page is refreshed,
or when browser history changes. This work will be tracked in DISCO-210.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
