### PR TITLE
Add route reactivity to Facet.vue

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -57,14 +57,31 @@ export default {
 
       this.$router.push({ query: newQuery });
     },
+    updateFacetsFromURL: function (query) {
+      this.checkedFacets = [];
+      for (const param in query) {
+        if (this.facetHeader == param && typeof query[param] == "string") {
+          this.checkedFacets.push(query[param]);
+        } else if (this.facetHeader == param && Array.isArray(query[param])) {
+          query[param].forEach((facet) => {
+            this.checkedFacets.push(facet);
+          });
+        }
+      }
+    },
   },
   mounted() {
-    this.$watch(
-      () => this.checkedFacets,
-      () => {
-        this.applyFacets();
-      }
-    );
+    if (this.$route.query) {
+      this.updateFacetsFromURL(this.$route.query);
+    }
+  },
+  watch: {
+    $route(to) {
+      this.updateFacetsFromURL(to.query);
+    },
+    checkedFacets() {
+      this.applyFacets();
+    },
   },
 };
 </script>

--- a/tests/unit/facet.spec.js
+++ b/tests/unit/facet.spec.js
@@ -26,15 +26,26 @@ describe("Facet.vue", () => {
       },
     });
 
-    wrapper.setData({ checkedFacets: ["english"] });
-
     expect(wrapper.text()).toMatch("language");
     expect(wrapper.text()).toMatch("english (1)");
     expect(wrapper.text()).toMatch("french (2)");
   });
 
   it("hides facet list if no facets are available", () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
     const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
       props: {
         facetList: [],
         facetHeader: "language",
@@ -73,5 +84,63 @@ describe("Facet.vue", () => {
 
     await checkbox.setValue(false);
     expect(wrapper.vm.checkedFacets).toEqual([]);
+  });
+
+  it("adds facets based on URL params", () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1", language: ["english"] },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [{ name: "english", count: 1 }],
+        facetHeader: "language",
+      },
+      data() {
+        return {
+          checkedFacets: [],
+        };
+      },
+    });
+
+    expect(wrapper.vm.$data.checkedFacets).toContain("english");
+  });
+
+  it("removes facets based on URL params", () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [{ name: "english", count: 1 }],
+        facetHeader: "language",
+      },
+      data() {
+        return {
+          checkedFacets: ["english"],
+        };
+      },
+    });
+
+    expect(wrapper.vm.$data.checkedFacets).toEqual([]);
   });
 });


### PR DESCRIPTION
#### Why these changes are being introduced:

Currently, Facet.vue does not react to changes in the route. This
means that the v-model resets whenever the page reloads, and does
not change when the browser history changes.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/DISCO-210

#### How this addresses that need:

This adds a route watcher that updates facets from the URL query
params, so whenever the route changes, the v-model updates accordingly.

#### Side effects of this change:

Some minor tweaks to facet.spec.js, in addition to coverage for
the new functionality.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
