### PR TITLE
Additional unit tests for Facet.vue

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -77,7 +77,9 @@ export default {
   },
   watch: {
     $route(to) {
-      this.updateFacetsFromURL(to.query);
+      if (to.query) {
+        this.updateFacetsFromURL(to.query);
+      }
     },
     checkedFacets() {
       this.applyFacets();

--- a/tests/unit/facet.spec.js
+++ b/tests/unit/facet.spec.js
@@ -105,11 +105,6 @@ describe("Facet.vue", () => {
         facetList: [{ name: "english", count: 1 }],
         facetHeader: "language",
       },
-      data() {
-        return {
-          checkedFacets: [],
-        };
-      },
     });
 
     expect(wrapper.vm.$data.checkedFacets).toContain("english");
@@ -142,5 +137,134 @@ describe("Facet.vue", () => {
     });
 
     expect(wrapper.vm.$data.checkedFacets).toEqual([]);
+  });
+
+  it("applies facets as strings when required", async () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [{ name: "cave in Switzerland", count: 1 }],
+        facetHeader: "source",
+      },
+    });
+
+    const checkbox = wrapper.find(
+      'input[type="checkbox"][value="cave in Switzerland"]'
+    );
+
+    await checkbox.setValue(true);
+
+    expect(wrapper.vm.checkedFacets).toEqual(["cave in Switzerland"]);
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      query: { page: 1, q: "cheese", source: "cave in Switzerland" },
+    });
+  });
+
+  it("applies facets as arrays when required", async () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [{ name: "romansh", count: 1 }],
+        facetHeader: "language",
+      },
+    });
+
+    const checkbox = wrapper.find('input[type="checkbox"][value="romansh"]');
+
+    await checkbox.setValue(true);
+
+    expect(wrapper.vm.checkedFacets).toEqual(["romansh"]);
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      query: { page: 1, q: "cheese", language: ["romansh"] },
+    });
+  });
+
+  it("reverts to page 1 when a facet is applied", async () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "5" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [{ name: "romansh", count: 1 }],
+        facetHeader: "language",
+      },
+    });
+
+    const checkbox = wrapper.find('input[type="checkbox"][value="romansh"]');
+
+    await checkbox.setValue(true);
+
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      query: { page: 1, q: "cheese", language: ["romansh"] },
+    });
+  });
+
+  it("reverts to page 1 when a facet is removed", async () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "5" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [{ name: "romansh", count: 1 }],
+        facetHeader: "language",
+      },
+    });
+
+    const checkbox = wrapper.find('input[type="checkbox"][value="romansh"]');
+
+    await checkbox.setValue(true);
+
+    expect(wrapper.vm.$data.checkedFacets).toEqual(["romansh"]);
+
+    await checkbox.setValue(false);
+
+    expect(wrapper.vm.$data.checkedFacets).toEqual([]);
+    expect(mockRouter.push).toHaveBeenCalledWith({
+      query: { page: 1, q: "cheese" },
+    });
   });
 });

--- a/tests/unit/results.spec.js
+++ b/tests/unit/results.spec.js
@@ -207,7 +207,7 @@ describe("Results.vue", () => {
     });
   });
 
-  it("uses brackets syntax in query strings for TIMDEX", async () => {
+  it("uses brackets syntax where appropriate in query strings", async () => {
     mockResponse = {
       status: 200,
       data: {


### PR DESCRIPTION
#### Why these changes are being introduced:

We need more robust unit testing for Facet.vue.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/DISCO-215

#### How this addresses that need:

* Tests that the query reverts to page 1 when facets are added or
removed
* Tests that facets are pushed to the router as the correct data
type

#### Side effects of this change:

I added a conditional to the route watcher in Facet.vue to confirm
that the route query exists.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
