### PR TITLE
Adds display names for facet headings

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -1,6 +1,6 @@
 <template>
   <dl v-if="facetList && facetList.length" class="facet">
-    <dt>{{ facetHeader }}</dt>
+    <dt>{{ facetDisplayName }}</dt>
     <dd v-for="(facet, index) in facetList" :key="index">
       <input
         type="checkbox"
@@ -29,6 +29,7 @@ export default {
   props: {
     facetList: Array,
     facetHeader: String,
+    facetDisplayName: String,
   },
   methods: {
     applyFacets: function () {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -15,6 +15,7 @@
         v-for="(facetList, facetHeader, index) in facetLists"
         :facetList="facetList"
         :facetHeader="facetHeader"
+        :facetDisplayName="facetHeaderFixer(facetHeader)"
         :key="index"
       >
       </Facet>
@@ -110,6 +111,21 @@ export default {
         this.status.error_message = error;
         this.status.error_message =
           "Starting over may help. If it does not, please let us know!";
+      }
+    },
+    facetHeaderFixer: function (facetHeader) {
+      if (facetHeader == "content_type") {
+        return "Content type";
+      } else if (facetHeader == "contributor") {
+        return "Author/contributor";
+      } else if (facetHeader == "literary_form") {
+        return "Literary form";
+      } else if (facetHeader == "content_format") {
+        return "Format";
+      } else if (facetHeader == "source") {
+        return "Source of data";
+      } else {
+        return facetHeader.charAt(0).toUpperCase() + facetHeader.slice(1);
       }
     },
   },

--- a/tests/unit/facet.spec.js
+++ b/tests/unit/facet.spec.js
@@ -23,10 +23,11 @@ describe("Facet.vue", () => {
           { name: "french", count: 2 },
         ],
         facetHeader: "language",
+        facetDisplayName: "Language",
       },
     });
 
-    expect(wrapper.text()).toMatch("language");
+    expect(wrapper.text()).toMatch("Language");
     expect(wrapper.text()).toMatch("english (1)");
     expect(wrapper.text()).toMatch("french (2)");
   });

--- a/tests/unit/results.spec.js
+++ b/tests/unit/results.spec.js
@@ -249,4 +249,161 @@ describe("Results.vue", () => {
       expect(wrapper.vm.$data.status.loading).toBe(false);
     });
   });
+
+  it("translates facet headers to display versions", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        hits: 2,
+        results: [
+          {
+            id: "002574584",
+            title: "Cheese",
+            source: "MIT Aleph",
+          },
+          {
+            id: "002574585",
+            title: "Fromage",
+            source: "MIT Aleph",
+          },
+        ],
+        aggregations: {
+          source: [
+            {
+              name: "mit aleph",
+              count: 143,
+            },
+          ],
+          content_format: [
+            {
+              name: "print volume",
+              count: 36,
+            },
+            {
+              name: "dvd-rom",
+              count: 5,
+            },
+          ],
+          subject: [
+            {
+              name: "children's songs.",
+              count: 3,
+            },
+            {
+              name: "cooking.",
+              count: 2,
+            },
+            {
+              name: "motion pictures.",
+              count: 2,
+            },
+          ],
+          contributor: [
+            {
+              name: "marvin, frankie.",
+              count: 12,
+            },
+            {
+              name: "brown, james, 1933-2006.",
+              count: 9,
+            },
+            {
+              name: "djll, tom.",
+              count: 7,
+            },
+            {
+              name: "dexter, al.",
+              count: 4,
+            },
+          ],
+          content_type: [
+            {
+              name: "text",
+              count: 100,
+            },
+            {
+              name: "sound recording",
+              count: 28,
+            },
+          ],
+          collection: [
+            {
+              name: "lint",
+              count: 111,
+            },
+            {
+              name: "fuzz",
+              count: 111,
+            },
+          ],
+          language: [
+            {
+              name: "english",
+              count: 111,
+            },
+            {
+              name: "french",
+              count: 22,
+            },
+            {
+              name: "no linguistic content",
+              count: 9,
+            },
+          ],
+          literary_form: [
+            {
+              name: "fiction",
+              count: 81,
+            },
+            {
+              name: "nonfiction",
+              count: 62,
+            },
+          ],
+        },
+      },
+    };
+
+    axios.get.mockImplementation(() => Promise.resolve(mockResponse));
+
+    const mockRoute = {
+      query: { q: "cheese" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub,
+        },
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/search?q=cheese"
+    );
+
+    expect(wrapper.vm.$data.status.loading).toBe(true);
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.vm.$data.hits).toBe(2);
+      expect(wrapper.text()).toMatch("Source of data");
+      expect(wrapper.text()).toMatch("Format");
+      expect(wrapper.text()).toMatch("Subject");
+      expect(wrapper.text()).toMatch("Author/contributor");
+      expect(wrapper.text()).toMatch("Collection");
+      expect(wrapper.text()).toMatch("Language");
+      expect(wrapper.text()).toMatch("Content type");
+      expect(wrapper.text()).toMatch("Literary form");
+    });
+  });
 });


### PR DESCRIPTION
**Why are these changes being introduced:**

* TIMDEX returns facet headings as programable data, not designed for
  humans to read. As DISCO UI intends for human involvement, we should
  translate some terms.

**How does this address that need:**

* This adds a new prop and a method that translates timdex to human
  for facet category names

#### How can a reviewer manually see the effects of these changes?

On a search results page, look at the facet heading names and ensure they match the expectations in the ticket.

#### Relevant tickets

- https://mitlibraries.atlassian.net/browse/DISCO-248

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
