### PR TITLE
DISCO-240 Fix bug in Facet.vue that breaks pagination

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -16,11 +16,14 @@
 </template>
 
 <script>
+const _ = require("lodash");
+
 export default {
   name: "Facet",
   data() {
     return {
       checkedFacets: [],
+      facetsUpdatedFromURL: false,
     };
   },
   props: {
@@ -47,7 +50,11 @@ export default {
       // We need to copy the route query instead of assigning it to a variable
       // for Vue reasons
       const newQuery = Object.assign({}, this.$route.query);
-      newQuery["page"] = 1;
+
+      // Set page to 1 unless facets were updated from URL
+      if (this.facetsUpdatedFromURL == false) {
+        newQuery["page"] = "1";
+      }
 
       if (facetsToApply && facetsToApply.length) {
         newQuery[facetHeader] = facetsToApply;
@@ -56,18 +63,28 @@ export default {
       }
 
       this.$router.push({ query: newQuery });
+      this.facetsUpdatedFromURL = false;
     },
     updateFacetsFromURL: function (query) {
       this.checkedFacets = [];
-      for (const param in query) {
-        if (this.facetHeader == param && typeof query[param] == "string") {
-          this.checkedFacets.push(query[param]);
-        } else if (this.facetHeader == param && Array.isArray(query[param])) {
-          query[param].forEach((facet) => {
+      const facetParams = _.omit(query, ["page", "q"]);
+
+      for (const param in facetParams) {
+        if (
+          this.facetHeader == param &&
+          typeof facetParams[param] == "string"
+        ) {
+          this.checkedFacets.push(facetParams[param]);
+        } else if (
+          this.facetHeader == param &&
+          Array.isArray(facetParams[param])
+        ) {
+          facetParams[param].forEach((facet) => {
             this.checkedFacets.push(facet);
           });
         }
       }
+      this.facetsUpdatedFromURL = true;
     },
   },
   mounted() {

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -117,7 +117,9 @@ export default {
     this.searchTimdex();
   },
   watch: {
-    $route: "searchTimdex",
+    $route() {
+      this.searchTimdex();
+    },
   },
 };
 </script>

--- a/tests/unit/pagination.spec.js
+++ b/tests/unit/pagination.spec.js
@@ -208,7 +208,7 @@ describe("Pagination.vue", () => {
     });
   });
 
-  it("goes to previous page when previous is clicked", () => {
+  it("goes to first page when first is clicked", () => {
     const mockRoute = {
       query: { q: "obscura", page: "3" },
     };


### PR DESCRIPTION
#### Why these changes are being introduced:

We want to return users to the first page of results when facets are
applied or removed. However, ince we added the updateFacetsFromURL()
method, it is impossible to access any results beyond page 1. This is
because updateFacetsFromURL() mutates the v-model, which calls
the applyFacets() method, which in turn reverts to page 1.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/DISCO-240

#### How this addresses that need:

Adds a boolean data property to track whether updateFacetsFromURL()
has been run. If it hasn't, applyFacets() will reset the page to 1,
then toggle that property to true.

#### Side effects of this change:

* Miscellaneous cleanup, including:
    * Fixing misnamed test
    * Updating watcher syntax in Results.vue
    * Using consistent syntax when accessing wrapper data
* The new syntax in the Results route watcher causes a small drop in
code coverage. In fact, this was never covered, and I'd argue that it
shouldn't be, since we would effectively be testing the framework.
* We will need to write our first integration tests to confirm the
debugged behavior when clicking the pagination buttons. I've begun
working on this and will continue it in a separate ticket/branch.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
