### PR TITLE
DISCO-246 Update formatting for facet elements

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -1,7 +1,7 @@
 <template>
-  <dl v-if="facetList && facetList.length" class="facet">
+  <dl v-if="facetList && facetList.length" class="list-unbulleted">
     <dt>{{ facetDisplayName }}</dt>
-    <dd v-for="(facet, index) in facetList" :key="index">
+    <dd v-for="(facet, index) in facetList" :key="index" class="copy-sup">
       <input
         type="checkbox"
         :id="facetHeader + '_' + facet.name"
@@ -105,3 +105,10 @@ export default {
   },
 };
 </script>
+
+<style>
+.wrap-content dt,
+.wrap-content dd {
+  margin-bottom: 0.5em;
+}
+</style>


### PR DESCRIPTION
#### Why these changes are being introduced:

Facet elements currently have too much weight, and facet headings 
have no bottom margins.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/DISCO-245
* https://mitlibraries.atlassian.net/browse/DISCO-246

#### How this addresses that need:

* Modifies margins for facet headings
* Modifies margins and font size for facet elements to match subject
headings in Record.vue.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
