### PR TITLE
DISCO-247 DISCO-249 Converts facet options to render using flexbox

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -106,9 +106,19 @@ export default {
 };
 </script>
 
-<style>
-.wrap-content dt,
-.wrap-content dd {
-  margin-bottom: 0.5em;
+<style lang="scss">
+.wrap-content {
+  dd {
+    align-items: flex-start;
+    display: flex;
+    margin-bottom: 0.5em;
+
+    input {
+      margin: 0 0.5em;
+    }
+  }
+  dt {
+    margin-bottom: 0.5em;
+  }
 }
 </style>


### PR DESCRIPTION
The default rendering for facet options is somewhat awkward, with a few different issues arising. Long labels wrap under the checkbox. Vertical alignment between the checkbox and the text is a bit off.

This converts facet checkboxes and their text labels to render using flexbox, rather than linearly as a line of text. This allows for more precise control over positioning, although it still isn't quite perfect.

#### Relevant tickets

- https://mitlibraries.atlassian.net/browse/DISCO-247
- https://mitlibraries.atlassian.net/browse/DISCO-249

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
