### PR TITLE
DISCO-250 Normalize source display names

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -9,7 +9,7 @@
         v-model="checkedFacets"
       />
       <label :for="facetHeader + '_' + facet.name">
-        {{ facet.name }} {{ "(" + facet.count + ")" }}</label
+        {{ normalizeSource(facet.name) }} {{ "(" + facet.count + ")" }}</label
       >
     </dd>
   </dl>
@@ -86,6 +86,19 @@ export default {
         }
       }
       this.facetsUpdatedFromURL = true;
+    },
+    normalizeSource: function (source) {
+      if (this.facetHeader == "source") {
+        if (source == "mit aleph") {
+          return "MIT Barton Catalog";
+        } else if (source == "dspace@mit") {
+          return "DSpace@MIT";
+        } else if (source == "mit archivesspace") {
+          return "MIT ArchivesSpace";
+        }
+      } else {
+        return source;
+      }
     },
   },
   mounted() {

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -20,7 +20,9 @@
       </li>
     </ul>
     <p v-if="result.source_link">
-      <a :href="result.source_link">View in {{ result.source || "source" }}</a>
+      <a :href="result.source_link"
+        >View in {{ normalizeSource(result.source) || "source" }}</a
+      >
     </p>
   </div>
 </template>
@@ -28,11 +30,14 @@
 <script>
 export default {
   name: "Item",
-  components: {},
   props: {
     result: Object,
   },
-  computed: {},
+  methods: {
+    normalizeSource: function (source) {
+      return source == "MIT Aleph" ? "MIT Barton Catalog" : source;
+    },
+  },
 };
 </script>
 

--- a/src/views/Record.vue
+++ b/src/views/Record.vue
@@ -91,7 +91,10 @@
               >{{ result.physical_description }}
             </li>
 
-            <li><span class="label">Database: </span>{{ result.source }}</li>
+            <li>
+              <span class="label">Database: </span
+              >{{ normalizeSource(result.source) }}
+            </li>
           </ul>
 
           <h3 v-if="result.subjects" class="section-title">Subject:</h3>
@@ -173,6 +176,9 @@ export default {
           this.status.error_title = "An unknown error occured.";
         }
       }
+    },
+    normalizeSource: function (source) {
+      return source == "MIT Aleph" ? "MIT Barton Catalog" : source;
     },
   },
   created() {

--- a/tests/unit/facet.spec.js
+++ b/tests/unit/facet.spec.js
@@ -32,6 +32,36 @@ describe("Facet.vue", () => {
     expect(wrapper.text()).toMatch("french (2)");
   });
 
+  it("normalizes sources", () => {
+    const mockRoute = {
+      query: { q: "cheese", page: "1" },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = shallowMount(Facet, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+      props: {
+        facetList: [
+          { name: "mit aleph", count: 1 },
+          { name: "dspace@mit", count: 2 },
+          { name: "mit archivesspace", count: 3 },
+        ],
+        facetHeader: "source",
+      },
+    });
+
+    expect(wrapper.text()).toMatch("MIT Barton Catalog (1)");
+    expect(wrapper.text()).toMatch("DSpace@MIT (2)");
+    expect(wrapper.text()).toMatch("MIT ArchivesSpace (3)");
+  });
+
   it("hides facet list if no facets are available", () => {
     const mockRoute = {
       query: { q: "cheese", page: "1" },

--- a/tests/unit/item.spec.js
+++ b/tests/unit/item.spec.js
@@ -244,4 +244,88 @@ describe("Item.vue", () => {
     expect(wrapper.text()).toMatch("Lastoson, Firsty (Creator)");
     expect(wrapper.text()).toMatch("Namenamenamename (contributor)");
   });
+
+  it("normalizes MIT Aleph source to MIT Barton Catalog", () => {
+    const $router = {
+      push: jest.fn(),
+    };
+    const $route = {
+      params: {
+        recordId: "000544411",
+      },
+    };
+
+    const result = {
+      title: "The great American novel",
+      source: "MIT Aleph",
+      source_link: "http://library.mit.edu/item/000544411",
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub,
+        },
+        mocks: { $route, $router },
+      },
+      props: { result },
+    });
+    expect(wrapper.text()).toMatch("MIT Barton Catalog");
+  });
+
+  it("does not attempt to normalize DSpace@MIT source", () => {
+    const $router = {
+      push: jest.fn(),
+    };
+    const $route = {
+      params: {
+        recordId: "000544411",
+      },
+    };
+
+    const result = {
+      title: "The great American novel",
+      source: "DSpace@MIT",
+      source_link: "http://library.mit.edu/item/000544411",
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub,
+        },
+        mocks: { $route, $router },
+      },
+      props: { result },
+    });
+    expect(wrapper.text()).toMatch("DSpace@MIT");
+  });
+
+  it("does not attempt to normalize MIT ArchivesSpace source", () => {
+    const $router = {
+      push: jest.fn(),
+    };
+    const $route = {
+      params: {
+        recordId: "000544411",
+      },
+    };
+
+    const result = {
+      title: "The great American novel",
+      source: "MIT ArchivesSpace",
+      source_link: "http://library.mit.edu/item/000544411",
+    };
+
+    const wrapper = mount(Item, {
+      global: {
+        components: {
+          RouterLink: RouterLinkStub,
+        },
+        mocks: { $route, $router },
+      },
+      props: { result },
+    });
+    expect(wrapper.text()).toMatch("MIT ArchivesSpace");
+  });
 });

--- a/tests/unit/record.spec.js
+++ b/tests/unit/record.spec.js
@@ -239,3 +239,137 @@ describe("invalid timdex record", () => {
     });
   });
 });
+
+describe("record metadata display", () => {
+  it("normalizes MIT Aleph source to MIT Barton Catalog", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        id: "002574584",
+        title: "Cheese",
+        source: "MIT Aleph",
+      },
+    };
+
+    axios.get.mockImplementation(() => Promise.resolve(mockResponse));
+
+    const mockRoute = {
+      params: {
+        recordId: "002574584",
+      },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = mount(Record, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/record/002574584"
+    );
+
+    expect(wrapper.vm.$data.status.loading).toBe(true);
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.text()).toMatch("Database: MIT Barton Catalog");
+    });
+  });
+
+  it("does not attempt to normalize DSpace@MIT source", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        id: "002574584",
+        title: "Cheese",
+        source: "DSpace@MIT",
+      },
+    };
+
+    axios.get.mockImplementation(() => Promise.resolve(mockResponse));
+
+    const mockRoute = {
+      params: {
+        recordId: "002574584",
+      },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = mount(Record, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/record/002574584"
+    );
+
+    expect(wrapper.vm.$data.status.loading).toBe(true);
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.text()).toMatch("Database: DSpace@MIT");
+    });
+  });
+
+  it("does not attempt to normalize MIT ArchivesSpace source", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        id: "002574584",
+        title: "Cheese",
+        source: "MIT ArchivesSpace",
+      },
+    };
+
+    axios.get.mockImplementation(() => Promise.resolve(mockResponse));
+
+    const mockRoute = {
+      params: {
+        recordId: "002574584",
+      },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = mount(Record, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      "https://timdex.example.com/api/v1/record/002574584"
+    );
+
+    expect(wrapper.vm.$data.status.loading).toBe(true);
+
+    await wrapper.vm.$nextTick(() => {
+      expect(wrapper.vm.$data.status.loading).toBe(false);
+      expect(wrapper.text()).toMatch("Database: MIT ArchivesSpace");
+    });
+  });
+});


### PR DESCRIPTION
#### Why these changes are being introduced:

The source element isn't normalized in TIMDEX aggregations, so
available facets render a less readable name (e.g., 'mit archivesspace'
instead of 'MIT ArchivesSpace').

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/DISCO-250

#### How this addresses that need:

Normalizes source in Facet.vue, Record.vue, and Item.vue. In Record
and Item, the only normalization required is 'MIT Aleph' to 'MIT
Barton Catalog', as Mario already normalizes DSpace and ASpace for us.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
