### PR TITLE
Centralizes source and handling of per_page prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository will focus on the `DISCO UI` portion of this work.
 ### Optional
 
 `VUE_APP_SENTRY_DSN`: set to Sentry project key to log exceptions
+`VUE_APP_RESULTS_PER_PAGE`: determines how many results are seen on one page. Defauls to 20 if not set.
 
 ## Project setup
 

--- a/src/components/SearchMetadata.vue
+++ b/src/components/SearchMetadata.vue
@@ -13,6 +13,7 @@ export default {
   name: "SearchMetadata",
   props: {
     hits: Number,
+    per_page: Number,
     searchterm: String,
   },
   methods: {
@@ -22,14 +23,11 @@ export default {
       }
       return 1;
     },
-    per_page() {
-      return 20;
-    },
     start() {
-      return this.per_page() * (this.page() - 1) + 1;
+      return parseInt(this.per_page) * (this.page() - 1) + 1;
     },
     end() {
-      return Math.min(this.page() * this.per_page(), this.hits);
+      return Math.min(this.page() * parseInt(this.per_page), this.hits);
     },
   },
 };

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -21,7 +21,11 @@
       </Facet>
     </div>
     <div v-bind:class="contentClass" v-if="this.status.loading == false">
-      <SearchMetadata v-model:searchterm="searchterm" v-model:hits="hits" />
+      <SearchMetadata
+        v-model:searchterm="searchterm"
+        v-model:hits="hits"
+        v-model:per_page="per_page"
+      />
       <div v-if="hits == 0">
         <p>Sorry, no results found for {{ searchterm }}.</p>
       </div>
@@ -59,7 +63,6 @@ export default {
       page: this.$route.query.page || "1",
       results: [],
       facetLists: [],
-      per_page: 20,
       status: {
         error_message: "",
         errored: false,
@@ -76,6 +79,12 @@ export default {
     },
     showSidebar: function () {
       return this.facetLists ? true : false;
+    },
+    per_page: function () {
+      if (process.env.VUE_APP_RESULTS_PER_PAGE) {
+        return parseInt(process.env.VUE_APP_RESULTS_PER_PAGE);
+      }
+      return 20;
     },
   },
   methods: {

--- a/tests/unit/results.spec.js
+++ b/tests/unit/results.spec.js
@@ -406,4 +406,74 @@ describe("Results.vue", () => {
       expect(wrapper.text()).toMatch("Literary form");
     });
   });
+
+  it("sets per_page to 20 if nothing is specified or defined", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        hits: 0,
+        results: [],
+      },
+    };
+
+    axios.get.mockImplementation(() => Promise.reject(mockResponse));
+
+    const mockRoute = {
+      query: {
+        q: "cheese",
+      },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+    });
+
+    delete process.env.VUE_APP_RESULTS_PER_PAGE;
+
+    expect(wrapper.vm.per_page).toEqual(20);
+  });
+
+  it("sets per_page based on an env var over the default", async () => {
+    mockResponse = {
+      status: 200,
+      data: {
+        hits: 0,
+        results: [],
+      },
+    };
+
+    axios.get.mockImplementation(() => Promise.reject(mockResponse));
+
+    const mockRoute = {
+      query: {
+        q: "cheese",
+      },
+    };
+    const mockRouter = {
+      push: jest.fn(),
+    };
+
+    const wrapper = mount(Results, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+      },
+    });
+
+    // We explicitly set this here because we cannot trust what you have set
+    // in env.
+    process.env.VUE_APP_RESULTS_PER_PAGE = 7;
+
+    expect(wrapper.vm.per_page).toEqual(7);
+  });
 });

--- a/tests/unit/searchmetadata.spec.js
+++ b/tests/unit/searchmetadata.spec.js
@@ -11,6 +11,7 @@ describe("SearchMetadata.vue", () => {
     };
 
     const hits = 6021023;
+    const per_page = 20;
     const searchterm = "new message";
     const wrapper = shallowMount(SearchMetadata, {
       global: {
@@ -19,7 +20,7 @@ describe("SearchMetadata.vue", () => {
           $router: mockRouter,
         },
       },
-      props: { hits, searchterm },
+      props: { hits, per_page, searchterm },
     });
 
     expect(wrapper.text()).toMatch("Search Results");
@@ -37,6 +38,7 @@ describe("SearchMetadata.vue", () => {
     };
 
     const hits = 49;
+    const per_page = 20;
     const wrapper = shallowMount(SearchMetadata, {
       global: {
         mocks: {
@@ -45,7 +47,7 @@ describe("SearchMetadata.vue", () => {
         },
       },
 
-      props: { hits },
+      props: { hits, per_page },
     });
 
     expect(wrapper.text()).toMatch("Viewing records 21 to 40 of " + hits);
@@ -60,6 +62,7 @@ describe("SearchMetadata.vue", () => {
     };
 
     const hits = 7;
+    const per_page = 20;
     const wrapper = shallowMount(SearchMetadata, {
       global: {
         mocks: {
@@ -68,7 +71,7 @@ describe("SearchMetadata.vue", () => {
         },
       },
 
-      props: { hits },
+      props: { hits, per_page },
     });
 
     expect(wrapper.text()).toMatch("Viewing records 1 to 7 of " + hits);
@@ -83,6 +86,7 @@ describe("SearchMetadata.vue", () => {
     };
 
     const hits = 38;
+    const per_page = 20;
     const wrapper = shallowMount(SearchMetadata, {
       global: {
         mocks: {
@@ -91,7 +95,7 @@ describe("SearchMetadata.vue", () => {
         },
       },
 
-      props: { hits },
+      props: { hits, per_page },
     });
 
     expect(wrapper.text()).toMatch("Viewing records 21 to 38 of " + hits);
@@ -106,6 +110,7 @@ describe("SearchMetadata.vue", () => {
     };
 
     const hits = 38;
+    const per_page = 20;
     const wrapper = shallowMount(SearchMetadata, {
       global: {
         mocks: {
@@ -114,7 +119,7 @@ describe("SearchMetadata.vue", () => {
         },
       },
 
-      props: { hits },
+      props: { hits, per_page },
     });
     expect(wrapper.text()).toMatch("Viewing records 1 to 20 of " + hits);
   });


### PR DESCRIPTION
This streamlines the definition and handling of how many results are displayed at a time. The underlying TIMDEX! API will only return 20 items at a time, so this is purely an internal cleanup effort. It defines a computed value inside the Results view, which is then passed to the SearchMetadata and Pagination components.

The Pagination component already accepted per_page as a prop, so the change here is really to SearchMetadata, and to how the Results view itself handled the value.

If the environment variable is not defined, the application falls back to 20 as a default.

#### How can a reviewer manually see the effects of these changes?

You can define a different value for `VUE_APP_RESULTS_PER_PAGE` in Heroku, and watch the pagination and search metadata change - but because Timdex doesn't support a size parameter, the query _into_ Timdex never changes, and the number of returned results never changes.

#### Relevant tickets

- https://mitlibraries.atlassian.net/browse/DISCO-209

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies

NO
